### PR TITLE
Hotfix: Make timestamp a top-level field

### DIFF
--- a/zubax/primitive/real32/ScalarVarTs.1.0.dsdl
+++ b/zubax/primitive/real32/ScalarVarTs.1.0.dsdl
@@ -1,3 +1,4 @@
-ScalarTs.1.0 value
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
+Scalar.1.0 value
 float32 error_variance
 @sealed

--- a/zubax/primitive/real32/Vector2VarTs.1.0.dsdl
+++ b/zubax/primitive/real32/Vector2VarTs.1.0.dsdl
@@ -1,3 +1,4 @@
-Vector2Ts.1.0 value
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
+Vector2.1.0 value
 float32[3] covariance_urt  # Upper-right triangle of the covariance matrix.
 @sealed

--- a/zubax/primitive/real32/Vector3VarTs.1.0.dsdl
+++ b/zubax/primitive/real32/Vector3VarTs.1.0.dsdl
@@ -1,3 +1,4 @@
-Vector3Ts.1.0 value
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
+Vector3.1.0 value
 float32[6] covariance_urt  # Upper-right triangle of the covariance matrix.
 @sealed

--- a/zubax/primitive/real32/Vector4VarTs.1.0.dsdl
+++ b/zubax/primitive/real32/Vector4VarTs.1.0.dsdl
@@ -1,4 +1,5 @@
-Vector4Ts.1.0 value
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
+Vector4.1.0 value
 float32[10] covariance_urt
 # Upper-right triangle of the covariance matrix:
 #       0   1   2   3

--- a/zubax/primitive/real32/Vector5VarTs.1.0.dsdl
+++ b/zubax/primitive/real32/Vector5VarTs.1.0.dsdl
@@ -1,4 +1,5 @@
-Vector5Ts.1.0 value
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
+Vector5.1.0 value
 float32[15] covariance_urt
 # Upper-right triangle of the covariance matrix:
 #       0   1   2   3   4

--- a/zubax/primitive/real32/Vector6VarTs.1.0.dsdl
+++ b/zubax/primitive/real32/Vector6VarTs.1.0.dsdl
@@ -1,4 +1,5 @@
-Vector6Ts.1.0 value
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
+Vector6.1.0 value
 float32[21] covariance_urt
 # Upper-right triangle of the covariance matrix:
 #       0   1   2   3   4   5

--- a/zubax/primitive/real32/Vector8VarTs.1.0.dsdl
+++ b/zubax/primitive/real32/Vector8VarTs.1.0.dsdl
@@ -1,4 +1,5 @@
-Vector8Ts.1.0 value
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
+Vector8.1.0 value
 float32[36] covariance_urt
 # Upper-right triangle of the covariance matrix:
 #       0   1   2   3   4   5   6   7

--- a/zubax/primitive/real32/Vector9VarTs.1.0.dsdl
+++ b/zubax/primitive/real32/Vector9VarTs.1.0.dsdl
@@ -1,4 +1,5 @@
-Vector9Ts.1.0 value
+uavcan.time.SynchronizedTimestamp.1.0 timestamp
+Vector9.1.0 value
 float32[45] covariance_urt
 # Upper-right triangle of the covariance matrix:
 #       0   1   2   3   4   5   6   7   8


### PR DESCRIPTION
This is to simplify time synchronization in generic code